### PR TITLE
chore(charon): bump image to sha-b24aa77 (RP-initiated logout)

### DIFF
--- a/charon/charon.yaml
+++ b/charon/charon.yaml
@@ -18,7 +18,7 @@ spec:
         app: charon
     spec:
       containers:
-        - image: ghcr.io/socialgouv/charon:sha-e6fc8bb
+        - image: ghcr.io/socialgouv/charon:sha-b24aa77
           name: app
           ports:
             - containerPort: 3000


### PR DESCRIPTION
## Summary

Bumps the charon image from `sha-e6fc8bb` to `sha-b24aa77` to pull in the new OIDC RP-initiated logout proxy handlers (https://github.com/SocialGouv/charon/pull/13, merge commit `b24aa77`).

## Why

Without this bump, charon's `/{provider}/session/end` route returns 404, and any client behind charon (including egapro) cannot kill the ProConnect SSO cookie on logout — clicking "Se déconnecter" only clears the local session, leaving the IdP session alive and silently re-logging the user in on the next click.

The new charon image adds:
- `/{provider}/session/end` (and `/{provider}/oauth/logout`) handlers that proxy the logout to the upstream IdP and rewrite `post_logout_redirect_uri` to a charon-controlled URL — same dynamic-dispatch trick already used for `/authorize`
- `/oauth/logout/callback` route that reads the original `post_logout_redirect_uri` from the charon session and redirects the browser back to the originating client (the per-PR / per-env app)

## Backward compatibility

`session/end` was previously a 404 — no client relied on its prior behaviour. Other providers (github, moncomptepro/moncompteprotest) are unaffected (analysis on the charon PR).

## Coordinated with

- charon: https://github.com/SocialGouv/charon/pull/13 (merged)
- egapro consumer: https://github.com/SocialGouv/egapro/pull/3347

## Test plan

- [ ] Image pulled and rolled out on charon
- [ ] After egapro PR is also deployed, verify on alpha that logout → re-login prompts for ProConnect credentials (no silent SSO)

## Pre-flight

- Image `ghcr.io/socialgouv/charon:sha-b24aa77` confirmed present in GHCR (manifest HTTP 200, multi-arch OCI index)