### PR TITLE
feat(buildkit): expose LB on :443 for GitLab PIC runners (3s-safe)

### DIFF
--- a/buildkit-service/templates/lb.svc.yaml
+++ b/buildkit-service/templates/lb.svc.yaml
@@ -10,6 +10,9 @@ spec:
   - name: tcp
     port: 1234
     targetPort: tcp
+  - name: https
+    port: 443
+    targetPort: tcp
   selector:
     app.kubernetes.io/instance: buildkit-service
     app.kubernetes.io/name: buildkit-service
@@ -25,6 +28,9 @@ spec:
   ports:
   - name: tcp
     port: 1234
+    targetPort: tcp
+  - name: https
+    port: 443
     targetPort: tcp
   selector:
     statefulset.kubernetes.io/pod-name: buildkit-service-{{ $i }}


### PR DESCRIPTION
## Objectif

Exposer le service **buildkit** sur le port **:443** (en plus de `:1234`) pour que les **runners GitLab PIC** puissent le joindre : leur seul egress sortant passe par le **proxy intranet** (`proxyweb.intranet.social.gouv.fr:8002`) qui n'autorise le `CONNECT` que sur **443**. Un tunnel proxy 443 (+ `buildctl --tlsservername`) permet alors d'atteindre buildkit.

## Changement

`buildkit-service/templates/lb.svc.yaml` : ajoute un port `443 → targetPort tcp(1234)` sur `svc` et `svc-0..N` (LoadBalancer). `:1234` est conservé (consommateurs existants intacts).

## Compatibilité 3s & ArgoCD

- **3s** (stateful-scaler) ne modifie que `Spec.Selector` des services `svc-*` (cf. `main.go` `updateServiceSelectors`) → il ne touche pas `Spec.Ports`, donc le port 443 n'est pas écrasé.
- L'**ApplicationSet** `buildkit-services` a déjà `ignoreDifferences` sur `/spec/selector` (pour 3s) et `automated` sync → le port 443 sera appliqué et stable.
- Le cert daemon couvre `*.buildkit.atlas.fabrique.social.gouv.fr` → le `--tlsservername` côté client reste valide.

## Après merge

ArgoCD synchronise → les LB écoutent aussi sur 443. Côté GitLab CI, on pointe `BUILDKIT_DAEMON_ADDRESS` sur `:443` + tunnel proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
