### PR TITLE
chore(iterion): bump ovh-prod v0.16.1 → v0.19.0 (author-filtered webhooks + Vetty)

### DIFF
--- a/iterion/values.ovh-prod.yaml
+++ b/iterion/values.ovh-prod.yaml
@@ -52,8 +52,10 @@ iterion:
   image:
     # Pinned tagged release (immutable, reproducible). ovh-dev/preprod tracks
     # main via :edge; ovh-prod runs the cut release. Bump on each release after
-    # validating on preprod. v0.16.1 is forward of v0.16.0 (ancestor-checked).
-    tag: v0.16.1
+    # validating on preprod. v0.19.0 is forward of v0.16.1 (ancestor-checked).
+    # v0.19.0 brings author-filtered webhooks + the Vetty dependency-PR guard
+    # (forge_token file-secret RBAC already provided by chart dep 0.17.2).
+    tag: v0.19.0
 
   server:
     replicas: 3


### PR DESCRIPTION
Bumps the **ovh-prod** iterion image to **v0.19.0** — the cut release carrying:
- **author-filtered webhooks** (`webhooks.Config.AuthorAllowlist` + `MatchAuthor`, `pr_author` var, orchestrator wiring) — lets a webhook react only to a dependency bot's PRs;
- **Vetty** (`bots/dep-update-guard`) — reactive supply-chain audit + code alignment + verdict comment for Dependabot/Renovate PRs.

## Safety
- **Ancestor-checked**: `v0.16.1` is an ancestor of `v0.19.0` (linear release history).
- **Chart dep unchanged** (`0.17.2`) — it already provides the per-run Secrets RBAC for `as: file` secrets (`forge_token`), which Vetty uses. No chart re-vendor required.
- Single-file change: `iterion/values.ovh-prod.yaml` (image tag only).

## ⚠️ Draft on purpose — do not merge yet
- This is a **large multi-release jump (0.16.1 → 0.19.0)**. Merge = ArgoCD rolls ovh-prod forward across SSO / marketplace / board / sandbox / etc.
- **Validate on ovh-dev preprod (`:edge` = main) first** (Vetty connect+enable + a real Dependabot PR run). Mark ready & merge only after that passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)