### PR TITLE
feat(token-bureau): grant egapro CI the org Projects V2 write scope (v0.0.8)

### DIFF
--- a/token-bureau/values.yaml
+++ b/token-bureau/values.yaml
@@ -2,10 +2,25 @@ token-bureau:
   image:
     # tag: latest
     # pullPolicy: Always
+    # NOTE: before merging, bump to the token-bureau release that includes
+    # SocialGouv/token-bureau#6 (adds `organization_projects` support). The
+    # `permissions` override below fails validatePermissions() on any older
+    # image (e.g. v0.0.7), which would break token-bureau org-wide.
     tag: v0.0.7
     pullPolicy: IfNotPresent
   replicaCount: 2
   existingSecret: token-bureau
+
+  # Grant SocialGouv/egapro's CI the org-level Projects V2 write scope (merged
+  # over the chart-default whitelist), needed by egapro's ticket-end-date
+  # workflow to stamp Start/End date on the EGAPRO V2 board. Other repos keep
+  # the default whitelist. Prerequisite: the token-bureau GitHub App must hold
+  # "Organization projects: Read and write".
+  permissions:
+    repositories:
+      "SocialGouv/egapro":
+        permissions:
+          organization_projects: write
 
   labels:
     oblik.socialgouv.io/enabled: "true"

--- a/token-bureau/values.yaml
+++ b/token-bureau/values.yaml
@@ -2,11 +2,10 @@ token-bureau:
   image:
     # tag: latest
     # pullPolicy: Always
-    # NOTE: before merging, bump to the token-bureau release that includes
-    # SocialGouv/token-bureau#6 (adds `organization_projects` support). The
-    # `permissions` override below fails validatePermissions() on any older
-    # image (e.g. v0.0.7), which would break token-bureau org-wide.
-    tag: v0.0.7
+    # v0.0.8 is the first release including SocialGouv/token-bureau#6, which
+    # adds `organization_projects` to VALID_PERMISSIONS — required by the
+    # `permissions` override below (older images throw at config load).
+    tag: v0.0.8
     pullPolicy: IfNotPresent
   replicaCount: 2
   existingSecret: token-bureau


### PR DESCRIPTION
## Why

`SocialGouv/egapro` adds a `ticket-end-date` workflow that stamps **Start date / End date** columns on its **org ProjectV2** board when a PR merges. That GraphQL write needs an installation token with **`organization_projects: write`** — the default `GITHUB_TOKEN` can't, so it uses a token-bureau App token.

## What

- Bump `image.tag` **v0.0.7 → v0.0.8** — v0.0.8 is the first release including [SocialGouv/token-bureau#6](https://github.com/SocialGouv/token-bureau/pull/6) (merged), which adds `organization_projects` to `VALID_PERMISSIONS`. Verified: `v0.0.8` is identical to `main`, which carries the change.
- Add a **repo-specific** whitelist override for `SocialGouv/egapro` only (merged over the chart-default whitelist). Other repos are unaffected.

```yaml
permissions:
  repositories:
    "SocialGouv/egapro":
      permissions:
        organization_projects: write
```

## Remaining prerequisite

The **token-bureau GitHub App** must hold *Organization projects: Read and write* (admin action — a config scope can't exceed what the App holds). Merging this PR is safe org-wide regardless (v0.0.8 accepts the key; only egapro's effective perms change), but egapro's workflow token will only carry the scope once the App is granted it.

Once merged (+ ArgoCD synced) and the App granted, egapro's workflow ([SocialGouv/egapro#3990](https://github.com/SocialGouv/egapro/pull/3990)) mints a projects-scoped token and the End-date automation goes live.
