### PR TITLE
fix(token-bureau): activer la sync automatique de l'ApplicationSet

### DIFF
--- a/applications/token-bureau.yaml
+++ b/applications/token-bureau.yaml
@@ -31,9 +31,13 @@ spec:
         syncOptions:
           - CreateNamespace=true
           #- Replace=true
-        # automated: 
-        #   prune: false # Specifies if resources should be pruned during auto-syncing ( false by default ).
-        #   selfHeal: false # Specifies if partial app sync should be executed when resources are changed only in target Kubernetes cluster and no git change detected ( false by default ).
+        # Without this, a change to token-bureau/values.yaml stays in git until
+        # someone syncs by hand — which is how the egapro Projects V2 grant sat
+        # undeployed for two weeks. prune/selfHeal stay off: this only makes a
+        # git change reach the cluster.
+        automated:
+          prune: false # Specifies if resources should be pruned during auto-syncing ( false by default ).
+          selfHeal: false # Specifies if partial app sync should be executed when resources are changed only in target Kubernetes cluster and no git change detected ( false by default ).
         retry:
           limit: 5
           backoff:


### PR DESCRIPTION
## Problème

`applications/token-bureau.yaml` a son bloc `syncPolicy.automated` commenté. Tout changement de `token-bureau/values.yaml` reste donc dans git jusqu'à ce que quelqu'un déclenche un sync à la main.

C'est exactement ce qui est arrivé à l'octroi du scope org Projects V2 à `SocialGouv/egapro` :

- `3e1a47c6` (22 juillet) — override `SocialGouv/egapro: { organization_projects: write }`, image `v0.0.8`
- `ef4e7970` (22 juillet) — `PERMISSIONS_CONFIG_PATH` branché sur le ConfigMap monté, image `v0.0.9`

Les deux commits sont bien sur `master` (= `targetRevision` de l'ApplicationSet), mais n'ont jamais atteint le cluster. Le serveur tourne encore la version d'avant — sans ConfigMap monté et sans `organization_projects` dans sa liste de permissions valides — et mint donc un token réduit aux défauts, **sans erreur au moment du mint**.

Conséquence côté `SocialGouv/egapro` : le workflow qui écrit la colonne *End date* du board a échoué à **chacun** de ses runs pendant deux semaines, sur une mutation Projects V2 refusée (`Resource not accessible by integration`), sans que rien ne signale que la cause était un déploiement en retard. Détail et correctif côté applicatif : SocialGouv/egapro#4105.

## Changement

Décommenter `syncPolicy.automated`, en gardant `prune: false` et `selfHeal: false` — l'idiome déjà utilisé ailleurs dans ce dépôt.

```yaml
        automated:
          prune: false
          selfHeal: false
```

Ça rend seulement un commit déployable sans intervention manuelle. Aucun changement de comportement d'ArgoCD vis-à-vis des ressources déjà en place : rien n'est pruné, et une dérive manuelle sur le cluster n'est pas écrasée.

## Après merge

Un **sync manuel reste nécessaire une fois** pour rattraper le retard accumulé depuis le 22 juillet. Ensuite, vérifier :

- pods sur `ghcr.io/socialgouv/token-bureau:v0.0.9`
- ConfigMap `token-bureau-permissions` contenant l'entrée `SocialGouv/egapro`

Si le mint renvoie alors une **422** (`The permissions requested are not granted to this installation`), il reste un second prérequis, indépendant de cette PR : l'App GitHub doit détenir *Organization permissions → Projects: Read and write*, **approuvée** par un owner sur l'installation — ajouter une permission à une App ne la donne pas rétroactivement aux installations existantes.
