### PR TITLE
feat(iterion): cap the fleet below the operator's own forfait

### DIFF
--- a/iterion/values.ovh-prod.yaml
+++ b/iterion/values.ovh-prod.yaml
@@ -226,6 +226,20 @@ iterion:
       # a shared instance would spend one person's balance for everyone.
       # (claude_code is unaffected either way; that path IS Claude Code.)
       ITERION_FORBID_SUBSCRIPTION_OAUTH: "0"
+      # Usage caps (docs/usage-caps.md). The Claude forfait this instance runs
+      # on is the OPERATOR's own, and it pays for their interactive work too —
+      # on 2026-08-17 the bots took the weekly window to 100% at 03:57 UTC,
+      # which is a dead week for the human as much as for the fleet. These
+      # stop iterion below the provider's wall, leaving the last quarter of
+      # the week to whoever is at the keyboard.
+      #
+      # The 5h window is SOFT by default (work in flight finishes, nothing new
+      # starts — it refills too soon to be worth killing a half-done run); the
+      # weekly one is HARD (a week that runs out on a Tuesday is worth more
+      # than the run that would have eaten it). A capped run parks with a
+      # durable retry for the window's reopening: it waits, it is not lost.
+      ITERION_USAGE_CAP_5H_PCT: "85"
+      ITERION_USAGE_CAP_WEEK_PCT: "75"
     log:
       format: json
       level: info # prod: info, not debug


### PR DESCRIPTION
Arms the usage caps shipped in SocialGouv/iterion#438 on `ovh-prod`.

```yaml
ITERION_USAGE_CAP_5H_PCT: "85"    # soft: work in flight finishes, nothing new starts
ITERION_USAGE_CAP_WEEK_PCT: "75"  # hard: the run stops where it stands
```

## Why

The Claude subscription this instance runs on is the operator's own, and it pays for their interactive work too. On 2026-08-17 the bots took the weekly window to 100% at 03:57 UTC — a dead week for the human as much as for the fleet (12 runs parked, the operator left at 92% with headroom only to 95%).

## Effect

`config.extraEnv` → configmap → runner `envFrom`, and the `checksum/config` pod annotation rolls the runner on sync.

A capped run parks with a durable retry armed for the window's reopening — it waits, it is not lost. **Expected on first sync:** the weekly window is currently above 75%, so runs will park until it resets (2026-08-18 21:00 UTC). That is the feature working, not an outage; `ITERION_USAGE_CAP=off` disarms both caps.

See [docs/usage-caps.md](https://github.com/SocialGouv/iterion/blob/main/docs/usage-caps.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)